### PR TITLE
update include.gradle

### DIFF
--- a/platforms/BROKEN android/include.gradle
+++ b/platforms/BROKEN android/include.gradle
@@ -6,8 +6,8 @@
 // 
 
 dependencies {
-	compile "com.onesignal:OneSignal:3.+@aar"
-	compile "com.google.android.gms:play-services-gcm:+"
-	compile "com.google.android.gms:play-services-location:+"
+	compile "com.onesignal:OneSignal:3.3.0"
+	compile "com.google.android.gms:play-services-gcm:9.2.0"
+	compile "com.google.android.gms:play-services-location:9.2.0"
 }
 


### PR DESCRIPTION
This should fix it. it has issues compiling libraries with versions of +. I've faced the same issue when working with firebase. Google playservice and service location should be 9.2.0.
