### PR TITLE
Make android includes compatible with firebase plugin.

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -9,8 +9,8 @@ android {
 }
 
 dependencies {
-	compile 'com.onesignal:OneSignal:3.+@aar'
-	compile 'com.google.android.gms:play-services-gcm:+'
-	compile 'com.google.android.gms:play-services-location:+'
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '+'
+    compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
+    compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
+    compile "com.onesignal:OneSignal:3.+@aar"
 }
-


### PR DESCRIPTION
The plugin has conflicts when trying to use it with firebase plugin.
This improvements goes along the line of nativescript-firebase plugin and nativescript-google-maps-sdk plugin to make all google play services plugins compatible.
