### PR TITLE
Remove @aar from Android dependency

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -1,4 +1,13 @@
-// 
+buildscript {
+    repositories {
+        maven { url 'https://plugins.gradle.org/m2/' } // Gradle Plugin Portal 
+    }
+    dependencies {
+        // https://github.com/OneSignal/OneSignal-Gradle-Plugin
+        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.10.1, 0.99.99]'
+    }
+}
+apply plugin: com.onesignal.androidsdk.GradleProjectPlugin
 
 android {
 	productFlavors {
@@ -6,6 +15,15 @@ android {
 			dimension 'nativescriptonesignal'
 		}
 	}
+
+// NOTE: The following section MUST be placed in your android {...} section in your app/build.gradle
+/*
+	defaultConfig {
+        manifestPlaceholders = [onesignal_app_id: "YOUR_ONESIGNAL_APP_ID",
+                                // Project number pulled from dashboard, local value is ignored.
+                                onesignal_google_project_number: 'REMOTE']
+    }
+ */
 }
 
 dependencies {

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -9,8 +9,5 @@ android {
 }
 
 dependencies {
-	compile 'com.onesignal:OneSignal:3.+@aar'
-	compile 'com.google.android.gms:play-services-gcm:+'
-	compile 'com.google.android.gms:play-services-location:+'
+	compile 'com.onesignal:OneSignal:3.9.1'
 }
-


### PR DESCRIPTION
* This will allow gradle to pull in all dependencies automatically
* Also locking to an exact version, the version should be updated and tested with each release