### PR TITLE
Fix adding maven to repositories

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -27,13 +27,6 @@ module.exports = function($logger, $projectData, hookArgs) {
       $logger.trace("Configuring Onesignal for Android");
       var search = -1;
 
-      var repositories = appBuildGradleContent.match(/repositories \{([^}]+)\}/gm);
-      if (!repositories) {
-          return;
-      }
-      search = appBuildGradleContent.indexOf(repositories[0]) + repositories[0].length;
-      appBuildGradleContent = appBuildGradleContent.substr(0, search) + \`\n	      maven { url "https://plugins.gradle.org/m2/" }\n\` + appBuildGradleContent.substr(search);
-
       search = appBuildGradleContent.indexOf("apply plugin: \\"com.android.application\\"");
       if (search == -1) {
           return;
@@ -68,7 +61,7 @@ module.exports = function($logger, $projectData, hookArgs) {
       if (!repositories) {
           return;
       }
-      search = buildGradleContent.indexOf(repositories[0]) + repositories[0].length;
+      search = (buildGradleContent.indexOf(repositories[0]) - 1) + (repositories[0].length - 1);
       buildGradleContent = buildGradleContent.substr(0, search) + \`\n	      maven { url "https://plugins.gradle.org/m2/" }\n\` + buildGradleContent.substr(search);
 
       search = buildGradleContent.indexOf("dependencies", search);


### PR DESCRIPTION
There are currently two problems with adding **maven** to the `repositories`.
1. When adding it to the `platforms/android/build.gradle` we need to add it before the closing `}` but not after it, that's why I'm subtracting 1 from the index and size of the matched block:
```JavaScript
search = (buildGradleContent.indexOf(repositories[0]) - 1) + (repositories[0].length - 1);
```
2. In the latest version of `platforms/android/app/build.gradle` in the **repositories** section we don't need to add the maven repository as it is already added in the `platforms/android/build.gradle` file.