### PR TITLE
Fixed build error when using NativeScript 6.

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -19,7 +19,7 @@ function writeFabricServiceGradleHook() {
 var path = require("path");
 var fs = require("fs");
 module.exports = function($logger, $projectData, hookArgs) {
-  var platform = hookArgs.platform.toLowerCase();
+  var platform = (hookArgs.platform || hookArgs.prepareData.platform).toLowerCase();
 
   function updateAppGradleScript(file) {
     var appBuildGradleContent = fs.readFileSync(file).toString();


### PR DESCRIPTION
Platform information is in `prepareData`  object of `hookArgs` as of NativeScript 6. This will make the post installation process compatible with both old and new versions.